### PR TITLE
loosen railties deps for rails v4

### DIFF
--- a/ts_routes.gemspec
+++ b/ts_routes.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_runtime_dependency "railties", ">= 5.0"
+  spec.add_runtime_dependency "railties", ">= 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
I confirmed to be able to use ts_routes-rails with rails v4.2.8
