### PR TITLE
Update the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 # The Revision History of TsRoutes
 
-## v1.0.2 2018/10/30
+## v1.0.3 2020-03-30
+
+* [#14](https://github.com/bitjourney/ts_routes-rails/pull/14): Reduce gem package size by removing package-lock.json
+
+## v1.0.2 2018-10-30
 
 * [#7](https://github.com/bitjourney/ts_routes-rails/pull/7): Loosen railties deps for rails v4 (by @mstssk)
 
-## v1.0.1 2017/07/19
+## v1.0.1 2017-07-19
 
 * Change the license from MIT to Apache 2.0
 * Tiny optimizations for generated code
 
-## v1.0.0 2017/06/27
+## v1.0.0 2017-06-27
 
 * Initial stable version


### PR DESCRIPTION
Mention #14 in the changelog.

Note that I updated the date format from yy/mm/dd to yy-mm-dd.
Because xx/xx/xx is ambiguous. It is yy/mm/dd for Japanese, but mm/dd/yy for American and dd/mm/yy for British.


ref: https://www.wantedly.com/companies/quipper/post_articles/214074 (Japanese blog)